### PR TITLE
feat: f Add automation for PR rejection 

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -12,6 +12,7 @@ export const LEVEL_LABEL = "level";
 export const ASSIGN_IDENTIFIER = "/assign" as const;
 export const CREATE_IDENTIFIER = "/oss.gg" as const;
 export const UNASSIGN_IDENTIFIER = "/unassign" as const;
+export const REJECT_IDENTIFIER = "/reject" as const;
 export enum EVENT_TRIGGERS {
   ISSUE_OPENED = "issues.opened",
   INSTALLATION_CREATED = "installation.created",
@@ -24,6 +25,18 @@ export const ON_NEW_ISSUE = "Thanks for opening an issue! It's live on oss.gg!";
 export const ON_REPO_NOT_REGISTERED = `This repository is not registered with oss.gg. Please register it at [oss.gg](https://oss.gg).`;
 export const ON_USER_NOT_REGISTERED = `you are not registered as a member of this repository, so you can't post oss.gg issues. Please register at [oss.gg](https://oss.gg).`;
 export const POINT_IS_NOT_A_NUMBER = "please provide a valid number of points to assign.";
+export const REJECTION_MESSAGE_TEMPLATE = (assignee: string, message: string) => `
+Hey @${assignee},
+
+Thanks a lot for the time and effort you put into shipping this! Unfortunately, we cannot accept your contribution for the following reason:
+
+${message}
+
+We will open the issue up for a different contributor to work on. Feel free to stick around in the community and pick up a different issue, if you like :)
+
+Thanks a lot!
+`;
+
 export const GITHUB_APP_ID = env.GITHUB_APP_ID as string;
 export const GITHUB_APP_PRIVATE_KEY = env.GITHUB_APP_PRIVATE_KEY as string;
 

--- a/lib/github/index.ts
+++ b/lib/github/index.ts
@@ -7,6 +7,7 @@ import {
   onAwardPoints,
   onIssueOpened,
   onPullRequestOpened,
+  onRejectCommented,
   onUnassignCommented,
 } from "./hooks/issue";
 
@@ -25,4 +26,5 @@ export const registerHooks = async () => {
   onUnassignCommented(webhooks);
   onAwardPoints(webhooks);
   onPullRequestOpened(webhooks);
+  onRejectCommented(webhooks);
 };


### PR DESCRIPTION

## What does this PR do?

fixes #47 

**Technical description**- since there is no persistent storage to store users whose pr is rejected , i am utilizing comment of GitHub. when /reject is executed for the first time a comment will be created "Attempted:user1". this comment is updated ,adding the new user ,every time the reject command is executed. this comment will be between the reject command and the rejection message. placement is important, as it makes it faster to catch this particular comment while looping through  all the comment in the issue comment section when the assign command is executed by the user whose pr is already rejected.

**## Message for the Maintainers**: 
Dear Maintainers reviewing my pr,  if you want any changes ,please tell me to make those changes and dont make them by yourself, as in this pr regex is being used at multiple places , one slight change will be very troublesome to catch. 

- **_I am not doubting your skills , you are maintainers for a reason, i am writing this for my sanity._**

## How should this be tested?

on an issue write /reject pr #prNumber message


### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at oss.gg](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
