### PR TITLE
fix: fix incorrect link for iPhone 16 with 512GB in Prizes section

### DIFF
--- a/app/(hacktoberfest)/page.tsx
+++ b/app/(hacktoberfest)/page.tsx
@@ -32,7 +32,7 @@ export default function IndexPage() {
             </li>
             <li>
               <Link
-                href="https://www.apple.com/iphone"
+                href="https://www.apple.com/iphone-16/"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="hover:underline">


### PR DESCRIPTION
What does this PR do?
This PR fixes a broken link in the "Prizes" section on the homepage. The link for 'iPhone 16 with 512GB' incorrectly points to the iPad landing page instead of the intended iPhone 16 page.

Fixes # (issue)

The broken link has been corrected to point to https://www.apple.com/iphone-16/.
How should this be tested?
Visit https://oss.gg/
Navigate to the "Prizes" section.
Click on 'iPhone 16 with 512GB.'
Verify that you are redirected to the correct iPhone 16 landing page.
Checklist
Required
 Filled out the "How to test" section in this PR
 Read [How we Code at oss.gg](https://formbricks.com/docs/contributing/how-we-code)
 Self-reviewed my own code
 Commented on my code in hard-to-understand bits
 Ran pnpm build
 Checked for warnings, there are none
 Removed all console.logs
 Merged the latest changes from main onto my branch with git pull origin main
 My changes don't cause any responsiveness issues
Appreciated
 If a UI change was made: Added a screen recording or screenshots to this PR
 Updated the Formbricks Docs if changes were necessary
Issue Summary
The link for 'iPhone 16 with 512GB' points to the iPad landing page instead of the iPhone 16 landing page on the homepage.

Steps to Reproduce
Visit https://oss.gg/
Explore the "Prizes" section.
Click on 'iPhone 16 with 512GB.'
Observe that you are redirected to the iPad landing page.
Expected behavior
The link should point to https://www.apple.com/iphone-16/.

Other information
No additional information.