### PR TITLE
feat: allow player to go to respective repo when clicked on logo.

### DIFF
--- a/app/[githubLogin]/components/point-list.tsx
+++ b/app/[githubLogin]/components/point-list.tsx
@@ -17,7 +17,9 @@ const PointsAndRanks: React.FC<PointsAndRanksProps> = ({ pointsAndRanks }) => {
       {pointsAndRanks.map((repo, index) => (
         <div key={repo.id} className="space-y-1">
           {repo.repositoryLogo && (
-            <Image src={repo.repositoryLogo} height={25} width={25} alt={`${repo.repositoryName} logo`} />
+            <a href={`https://github.com/${repo.repositoryName}`}>
+              <Image src={repo.repositoryLogo} height={25} width={25} alt={`${repo.repositoryName} logo`} />
+            </a>
           )}
           <h3 className="font-semibold">{repo.repositoryName}</h3>
           <p>points: {repo.points}</p>


### PR DESCRIPTION
Feature #133 

## What does this PR do?
This PR enhances the user experience by wrapping the repository logos in anchor tags, linking to their respective GitHub repositories. This change allows users to easily navigate to the repositories directly from the player interface.

## How should this be tested?

- Test A
-- Go to https://oss.gg/<[githubLogin]>
-- Click on the Image/logo of any availabe organization repositories and it should take to their respective github repo.

## Dependencies
No additional dependencies are required for this change.

## Checklist
- [✓] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at oss.gg](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [✓] Self-reviewed my own code
- [✓] Commented on my code in hard-to-understand bits , its not hard to understand
- [✓] Ran `pnpm build`
- [✓] Checked for warnings, there are none
- [✓] Removed all `console.logs`
- [✓] Merged the latest changes from main onto my branch with `git pull origin main`
- [✓] My changes don't cause any responsiveness issues